### PR TITLE
allows GitHub to display the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
-﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title>Hear Kitty</title>
 <link rel="stylesheet" type="text/css" href="VgerCore/VgerCore.css" />
 </head>
 <body>


### PR DESCRIPTION
I'm actually really impressed at how easy this was to change. I expected to have to rework the whole thing to be markdown.

If you don't remove the title, it shows `<title>Hear Kitty</title>` at the top, which is less than ideal.