### PR TITLE
Update Monk teachings max stack to 4

### DIFF
--- a/HearKitty.lua
+++ b/HearKitty.lua
@@ -236,7 +236,7 @@ function KittyOnBuffsChange()
 		BuffCharges = KittyAuraStacks("player", "PLAYER HELPFUL", 202090)
 		if BuffCharges then
 			KittyThisResourceDecays = false
-			KittyCurrentMaxStacks = 3
+			KittyCurrentMaxStacks = 4
 		end
 	end
 


### PR DESCRIPTION
The 11.0 patch updated the Monk passive Teachings of the Monastery to stack up to 4 times instead of 3.