### PR TITLE
Avoid playing sounds when using druid specs that do not utilize combo points or astral power

### DIFF
--- a/HearKitty.lua
+++ b/HearKitty.lua
@@ -399,19 +399,10 @@ end
 function KittyOnAstralPowerChange()
 	local AstralPower = UnitPower("player", Enum.PowerType.AstralPower)
 
-	-- Druid's do not need Astral Power change sounds unless in Balance spec. This happens since 11.0 due to the new Elune's Chosen talent tree and the "Evoke the Spirits" spell, which
-	-- are both available in druid specs that do not utilize Astral Power.
-	local className, classEnglish, classID = UnitClass("player")
-	if classEnglish == "DRUID" then
-		local specIndex = GetSpecialization()
-		if specIndex then
-			local specID, specName = GetSpecializationInfo(specIndex)
-			if specName ~= "Balance" then
-				if KittyDebug then VgerCore.Message("Druid: Astral Power change event ignored since not in Balance Spec.") end
-				return
-			end
-		end
-	end
+	-- Druids do not need Astral Power change sounds unless in Balance spec. Astral power updates started firing in 11.0 for non-balance specs when using the Elune's Chosen hero class or the Convoke the Spirits talent.
+	-- Also, ignore astral power changes when in cat form in any spec, since we can only track one resource at a time.
+	local _, Class = UnitClass("player")
+	if Class ~= "DRUID" or not GetSpecialization or GetSpecialization() ~= 1 or GetShapeshiftFormID() == 1 then return end
 
 	-- Get the relevant talent and Eclipse states.
 	local _, _, _, SoulOfTheForestSelected = GetTalentInfo(5, 1, 1) -- (surprisingly, this still works in 10.0 where it's no longer in that position)
@@ -456,18 +447,9 @@ end
 function KittyOnComboPointsChange(Unit)
 	local ComboPoints
 
-	-- Druid's do not need Combo Points change sounds unless in Feral spec.  This fires sometimes with Guardian because "Convoke the Spirits" will often spew Feral spells/abilities.
-	local className, classEnglish, classID = UnitClass("player")
-	if classEnglish == "DRUID" then
-		local specIndex = GetSpecialization()
-		if specIndex then
-			local specID, specName = GetSpecializationInfo(specIndex)
-			if specName ~= "Feral" then
-				if KittyDebug then VgerCore.Message("Druid: Combo points change event ignored since not in Feral Spec.") end
-				return
-			end
-		end
-	end
+	-- Ignore combo point changes for druids not in cat form, such as when combo points decay after leaving cat form, or when the Convoke the Spirits uses cat form abilities in other forms.
+	local _, Class = UnitClass("player")
+	if Class == "DRUID" and GetShapeshiftFormID() ~= 1 then return end
 
 	if GetComboPoints and Unit == "vehicle" then
 		-- WoW 7.0 (in beta) has a bug where vehicle combo points raise the UNIT_POWER event, but can only be retrieved with the legacy GetComboPoints.

--- a/HearKitty.lua
+++ b/HearKitty.lua
@@ -88,8 +88,6 @@ function KittyOnEvent(self, Event, arg1, arg2)
 		if Class == "DEATHKNIGHT" then PetHasInterestingBuffs = true end
 	end
 
-	
-
 	if Event == "UNIT_POWER_UPDATE" and (arg1 == "player" or arg1 == "vehicle") and arg2 == "COMBO_POINTS" then
 		KittyOnComboPointsChange(arg1)
 	elseif Event == "UNIT_POWER_UPDATE" and arg1 == "player" then

--- a/Readme.htm
+++ b/Readme.htm
@@ -150,7 +150,7 @@ information, see the readme that comes with the Gyro mod.</p>
 <h2>Release history</h2>
 <h3>Version 1.11.3</h3>
 <ul>
-	<li></li>
+	<li>The War Within: Fixed problems where druid talents like Convoke the Spirits could cause Hear Kitty to play sounds for combo points and astral power changes at unhelpful times. (Thanks Amadeus!)</li>
 </ul>
 <h3>Version 1.11.2</h3>
 <ul>


### PR DESCRIPTION
This pull request will avoid sounds playing while in druid specs that do not utilize combo points or astral power.   As it is right now, sounds are playing quite a bit while playing in Guardian spec, and this addresses that issue.

The code diff should be pretty self-explanatory what it does.

I also moved a few debug messages to before the next function call so that debug messages are in the right order. 

Thanks!